### PR TITLE
Fix issues with flattening styles.

### DIFF
--- a/src/component-to-node.ts
+++ b/src/component-to-node.ts
@@ -1,3 +1,4 @@
+import { StyleSheet } from "react-native"
 import * as yoga from "yoga-layout"
 import extractText from "./extract-text"
 import { Component, Settings } from "./index"
@@ -115,11 +116,7 @@ export const styleFromComponent = (component: Component) => {
     let style = component.props.style
 
     if (Array.isArray(style)) {
-      // The Stylesheet object allows some serious nesting of styles
-      const flattened = Array.prototype.concat.apply([], style)
-      const themeFlattened = Array.prototype.concat.apply([], flattened) as any[]
-      const objectsOnly = themeFlattened.filter(f => f)
-      style = Object.assign({}, ...objectsOnly)
+        style = Object.assign({}, StyleSheet.flatten(style))
     }
 
     return style

--- a/src/extract-text.ts
+++ b/src/extract-text.ts
@@ -1,10 +1,9 @@
+import { StyleSheet } from "react-native"
 export interface AttributedStyle { start: number, end: number, style: any }
 
 export interface TextWithAttributedStyle { text: string, attributedStyles: AttributedStyle[] }
 
-const flattenStyles = (styles): object => Array.isArray(styles)
-  ? Object.assign({}, ...styles)
-  : (styles || {})
+const flattenStyles = (styles): object => Object.assign({}, StyleSheet.flatten(styles))
 
 const getStyles = component => flattenStyles(component.props.style)
 


### PR DESCRIPTION
Text styles were not flattening arrays within arrays, normal styles were
only flattening to 2 layers deep. Replaced logic with React-Native's
StyleSheet.flatten function. This has the benefit that the final style
will exactly match what React-Native would use.