### PR TITLE
Merge external-api definitions into generated index.d.ts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "files": [
     "build/*"
   ],
-  "typings": "build/external-api.d.ts",
+  "typings": "build/index.d.ts",
   "author": "Orta Therox <orta.therox@gmail.com> & Art.sy Inc",
   "license": "MIT",
   "devDependencies": {
@@ -30,7 +30,7 @@
   "scripts": {
     "test": "jest",
     "type-check": "tsc --noEmit",
-    "build": "tsc && cp src/external-api.d.ts build",
+    "build": "tsc",
     "watch": "tsc --watch",
     "lint": "tslint 'src/**/*.{ts,tsx}'",
     "precommit": "lint-staged",

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,12 +1,3 @@
-// Add our matcher to Jest's definitions
-
-declare namespace jest {
-  interface Matchers<R> {
-    /** Checks and sets up SVG rendering for React Components. */
-    toMatchSVGSnapshot(width: number, height: number, settings?: { wireframe?: boolean }): void;
-  }
-}
-
 // Initial stub of the Yoga type system
 // Based on https://facebook.github.io/yoga/docs/api/javascript/
 //

--- a/src/external-api.d.ts
+++ b/src/external-api.d.ts
@@ -1,6 +1,0 @@
-declare namespace jest {
-  interface Matchers<R> {
-    /** Checks and sets up SVG rendering for React Components. */
-    toMatchSVGSnapshot(width: number, height: number, settings?: { wireframe?: boolean }): void;
-  }
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,17 @@ import * as path from "path"
 
 import * as yoga from "yoga-layout"
 
+// Add toMatchSVGSnapshot to jest definitions. Specified here so that it is output into
+// the index.d.ts definitions provided for projects to use.
+declare global {
+    namespace jest {
+        interface Matchers<R> {
+            /** Checks and sets up SVG rendering for React Components. */
+            toMatchSVGSnapshot(width: number, height: number, settings?: { wireframe?: boolean }): void;
+        }
+    }
+}
+
 export interface Component {
     type: string
     props: any


### PR DESCRIPTION
Projects using jest-snapshots-svg need access to both the external-api and
module definitions, but the package.json could only specify a single entry
file for defining types. Moving the ambient global jest definition into
index.ts results in this definition being merged into the same index.d.ts
definition file used for the module definitions. This means that both are
then usable by projects that import jest-snapshots-svg.