### PR TITLE
[feature]: Ability to add relative font path css definitions to svg.

### DIFF
--- a/src/_tests/example_layouts/__snapshots__/_text.test.tsx-does-not-break-if-a-text-tag-is-empty.svg
+++ b/src/_tests/example_layouts/__snapshots__/_text.test.tsx-does-not-break-if-a-text-tag-is-empty.svg
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <svg width="320" height="480" xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <defs>
+    <style type="text/css">
+    <![CDATA[
+      @font-face {
+        font-family: Proza Libre;
+        src: url(../../../font/proza-libre/ProzaLibre-Regular.ttf);
+        font-weight: 400;
+        font-style: normal;
+      }
+    ]]>
+    </style>
+  </defs>
 
  <rect type="View" x="0" y="0" width="320" height="480" fill="none"/>
 

--- a/src/_tests/example_layouts/__snapshots__/_text.test.tsx-renders-text-in-the-correct-place-when-positioned-with-flex.svg
+++ b/src/_tests/example_layouts/__snapshots__/_text.test.tsx-renders-text-in-the-correct-place-when-positioned-with-flex.svg
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <svg width="320" height="480" xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <defs>
+    <style type="text/css">
+    <![CDATA[
+      @font-face {
+        font-family: Proza Libre;
+        src: url(../../../font/proza-libre/ProzaLibre-Regular.ttf);
+        font-weight: 400;
+        font-style: normal;
+      }
+    ]]>
+    </style>
+  </defs>
 
  <rect type="View" x="0" y="0" width="500" height="500" fill="none"/>
 

--- a/src/_tests/example_layouts/__snapshots__/_text.test.tsx-renders-text-using-the-specified-default-font.svg
+++ b/src/_tests/example_layouts/__snapshots__/_text.test.tsx-renders-text-using-the-specified-default-font.svg
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <svg width="320" height="480" xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <defs>
+    <style type="text/css">
+    <![CDATA[
+      @font-face {
+        font-family: Proza Libre;
+        src: url(../../../font/proza-libre/ProzaLibre-Regular.ttf);
+        font-weight: 400;
+        font-style: normal;
+      }
+    ]]>
+    </style>
+  </defs>
 
  <rect type="View" x="0" y="0" width="320" height="480" fill="none"/>
 

--- a/src/component-to-node.ts
+++ b/src/component-to-node.ts
@@ -113,13 +113,13 @@ const componentToNode = (component: Component, settings: Settings): yoga.NodeIns
 }
 
 export const styleFromComponent = (component: Component) => {
-    let style = component.props.style
+  let style = component.props.style
 
-    if (Array.isArray(style)) {
-        style = flattenStyles(style)
-    }
+  if (Array.isArray(style)) {
+    style = flattenStyles(style)
+  }
 
-    return style
+  return style
 }
 
 export default componentToNode

--- a/src/extract-text.ts
+++ b/src/extract-text.ts
@@ -1,5 +1,5 @@
 import { flattenStyles } from "./flatten-styles"
-import { getDefaultFont } from "./font-loader"
+import { getDefaultFont, registerFontUsed } from "./font-loader"
 export interface AttributedStyle { start: number, end: number, style: any }
 
 export interface TextWithAttributedStyle { text: string, attributedStyles: AttributedStyle[] }
@@ -41,6 +41,7 @@ export default (component): TextWithAttributedStyle => {
 
   const defaultStylesWithFont = mergeStyles(defaultStyles, { fontFamily: getDefaultFont() })
   const iterate = (c, style = mergeStyles(defaultStylesWithFont, getStyles(c))) => {
+    registerFontUsed(style.fontFamily, style.fontWeight, style.fontStyle);
     (c.children || []).forEach(child => {
       if (child == null) {
         /* Do nothing */

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ import treeToSVG from "./tree-to-svg"
 
 const fail = (msg) => ({ message: () => msg, pass: false })
 
-export { addFontFallback, loadFont, setDefaultFont } from "./font-loader"
+export { addFontFallback, addFontToSvg, loadFont, setDefaultFont } from "./font-loader"
 
 expect.extend({
     toMatchSVGSnapshot(
@@ -99,7 +99,7 @@ expect.extend({
         const renderedComponentRoot = renderedComponentTree(root, rootNode)
         rootNode.freeRecursive()
 
-        const svgText = treeToSVG(renderedComponentRoot, settings)
+        const svgText = treeToSVG(renderedComponentRoot, settings, snapshotsDir)
 
         // TODO: Determine if Jest is in `-u`?
         // can be done via the private API

--- a/src/node-to-svg.ts
+++ b/src/node-to-svg.ts
@@ -29,8 +29,8 @@ const nodeToSVG = (indent: number, node: RenderedComponent, settings: Settings) 
   }
 
   return "\n"
-          + wsp(indent)
-          + svgText
+    + wsp(indent)
+    + svgText
 }
 
 export default nodeToSVG

--- a/src/tree-to-svg.ts
+++ b/src/tree-to-svg.ts
@@ -1,4 +1,6 @@
+import * as path from "path"
 import * as yoga from "yoga-layout"
+import { getSvgFonts, getUsedFontKeys } from "./font-loader"
 import { RenderedComponent, Settings } from "./index"
 import nodeToSVG from "./node-to-svg"
 import wsp from "./whitespace"
@@ -26,10 +28,47 @@ export const recurseTree =
     })
   }
 
-export const svgWrapper = (bodyText: string, settings: Settings) =>
+const svgFonts = (snapshotsDir?: string) => {
+  if (!snapshotsDir) {
+    return ""
+  }
+
+  const fonts = getSvgFonts()
+  const used = getUsedFontKeys()
+  const keys = Object.keys(fonts).filter((key) => used.includes(key))
+  if (keys.length === 0) {
+    return ""
+  }
+
+  let svgText = `  <defs>
+    <style type="text/css">
+    <![CDATA[
+`
+  keys.forEach((key) => {
+    const font = fonts[key]
+
+    svgText += `      @font-face {
+        font-family: ${font.style.fontFamily};
+        src: url(${path.relative(snapshotsDir, font.path)});\n`
+    if (font.style.fontWeight) {
+      svgText += `        font-weight: ${font.style.fontWeight};\n`
+    }
+    if (font.style.fontStyle) {
+      svgText += `        font-style: ${font.style.fontStyle};\n`
+    }
+    svgText += `      }\n`
+  })
+  svgText += `    ]]>
+    </style>
+  </defs>
+`
+  return svgText
+}
+
+export const svgWrapper = (bodyText: string, settings: Settings, snapshotsDir?: string) =>
   `<?xml version="1.0" encoding="UTF-8" ?>
 <svg width="${settings.width}" height="${settings.height}" xmlns="http://www.w3.org/2000/svg" version="1.1">
-${bodyText}
+${svgFonts(snapshotsDir)}${bodyText}
 </svg>
 `
 
@@ -39,8 +78,8 @@ ${wsp(indent)}<g transform='translate(${node.layout.left}, ${node.layout.top})'>
 ${wsp(indent)}</g>
 `
 
-const treeToSVG = (root: RenderedComponent, settings: Settings) => {
-  return svgWrapper(recurseTree(0, root, settings), settings)
+const treeToSVG = (root: RenderedComponent, settings: Settings, snapshotsDir?: string) => {
+  return svgWrapper(recurseTree(0, root, settings), settings, snapshotsDir)
 }
 
 export default treeToSVG


### PR DESCRIPTION
When trying to test a component that uses a specific font (e.g. a vector
icon font), it is important to be able to actually see the correct text
in the svg. If the font url is not specified and has not been installed on
the system itself (which fonts like "FontAwesome" are unlikely to be), the
characters display as only an empty box. By specifying the font in the
style tag of the svg, the characters can be displayed properly.